### PR TITLE
Ghost version

### DIFF
--- a/ghost-single.yaml
+++ b/ghost-single.yaml
@@ -14,6 +14,7 @@ parameter_groups:
   parameters:
   - domain
   - username
+  - version
 
 - label: rax-dev-params
   # These are parameters that will not be displayed in the portal. The purpose
@@ -70,6 +71,15 @@ parameters:
     constraints:
     - allowed_pattern: "^[a-zA-Z0-9.-]{1,255}.[a-zA-Z]{2,15}$"
       description: Must be a valid domain name
+
+  version:
+    label: Ghost version
+    description: Ghost version to be used
+    type: string
+    default: latest
+    constraints:
+    - allowed_pattern: "^\\d{1,2}\\.\\d{1,2}\\.\\d{1,2}$|latest"
+      description: Must be a valid Ghost version.
 
   # Database and system user configuration
   database_name:
@@ -170,6 +180,8 @@ resources:
           db_user: { get_param: username }
           db_password: { get_attr: [database_password, value] }
           password: { get_attr: [user_password, value] }
+          domain: { get_param: domain }
+          ghost_version: { get_param: version }
         hollandbackup:
           main:
             backup_directory: "/var/lib/mysqlbackup"


### PR DESCRIPTION
Allows the user to input the ghost version to install. Line 183 is a fix for domain because it wasn't being set in the template.
