### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here is an example of how to deploy this template using the
 heat --os-username <OS-USERNAME> --os-password <OS-PASSWORD> --os-tenant-id \
   <TENANT-ID> --os-auth-url https://identity.api.rackspacecloud.com/v2.0/ \
   stack-create Ghost-Stack -f ghost-single.yaml \
-  -P flavor="4 GB Performance Instance"
+  -P flavor="4 GB Performance"
 ```
 
 * For UK customers, use `https://lon.identity.api.rackspacecloud.com/v2.0/` as


### PR DESCRIPTION
Available Performance flavors are "X GB Performance", README.md listed "4 GB Performance Instance" as an example causing the following error "ERROR: Parameter 'flavor' is invalid: Must be a valid Rackspace Cloud Server flavor for the region you have selected to deploy into.".
